### PR TITLE
Smarter log parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 > a GitHub App built with [probot](https://github.com/probot/probot) that pastes the error output of a failing commit into the relevant PR.
 
-Currently supports TravisCI and CircleCI with "simple" setups running off of a single `npm test` script.
+Currently supports TravisCI and CircleCI. If you're interested in seeing support for another CI tool, please [open an issue!](https://github.com/JasonEtco/ci-reporter/issues/new)
+
+## 
 
 ## Setup
 
@@ -13,5 +15,3 @@ npm install
 # Run the bot
 npm start
 ```
-
-See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this app.

--- a/lib/providers/Circle.js
+++ b/lib/providers/Circle.js
@@ -46,11 +46,12 @@ class Circle {
       const prUrl = buildJson.pull_requests[0].url
       const number = prUrl.substr(prUrl.lastIndexOf('/')).substr(1)
 
-      const npmTestStep = buildJson.steps.find(step => step.name === 'npm test')
+      const failedStep = buildJson.steps.find(step => step.actions.some(action => action.exit_code === 1))
+      const failedAction = failedStep.actions.find(action => action.exit_code === 1)
 
       const res = await request({
         json: true,
-        uri: npmTestStep.actions[0].output_url,
+        uri: failedAction.output_url,
         gzip: true,
         headers: { Accept: 'application/json' }
       })
@@ -61,6 +62,7 @@ class Circle {
         number: parseInt(number, 10),
         data: {
           provider: 'Circle CI',
+          command: failedStep.name,
           content,
           targetUrl
         }

--- a/lib/providers/Circle.js
+++ b/lib/providers/Circle.js
@@ -47,7 +47,7 @@ class Circle {
       const number = prUrl.substr(prUrl.lastIndexOf('/')).substr(1)
 
       const failedStep = buildJson.steps.find(step => step.actions.some(action => action.exit_code === 1))
-      const failedAction = failedStep.actions.find(action => action.exit_code === 1)
+      const failedAction = failedStep.actions[failedStep.actions.length - 1]
 
       const res = await request({
         json: true,

--- a/lib/providers/Travis.js
+++ b/lib/providers/Travis.js
@@ -14,18 +14,13 @@ class Travis {
 
   parseLog (log) {
     // sp00ky RegExp to start the extraction
-    const start = new RegExp(/\$ npm test[\s\S]+?(?=>)/g)
-    const end = 'Test failed.  See above for more details.'
-
-    // Get the content between the test and end strings
-    let content = log.substring(log.search(start), log.indexOf(end))
-
-    // Remove the start string
-    content = content.replace(start, '')
+    const reg = /(\[0K\$\s)(?![\s\S]+\1)(.+)\n{2}([\s\S]+)Test failed\./g
+    const result = reg.exec(log)
+    // const command = result[2]
+    let content = result[3]
 
     // Remove the last line, it's usually extra
     content = content.substring(0, content.lastIndexOf('\n'))
-
     return content
   }
 

--- a/lib/providers/Travis.js
+++ b/lib/providers/Travis.js
@@ -17,9 +17,9 @@ class Travis {
     const reg = /(\[0K\$\s)(?![\s\S]+\1)(.+)\n{2}([\s\S]+)\n.+Test failed\./g
     const result = reg.exec(log)
 
-    // const command = result[2]
+    const command = result[2]
     let content = result[3]
-    return content
+    return { command, content }
   }
 
   async serialize () {
@@ -41,14 +41,15 @@ class Travis {
       headers
     })
 
-    const content = this.parseLog(res.content)
+    const { command, content } = this.parseLog(res.content)
 
     return {
       number: buildJson.pull_request_number,
       data: {
         provider: 'Travis CI',
         content,
-        targetUrl
+        targetUrl,
+        command
       }
     }
   }

--- a/lib/providers/Travis.js
+++ b/lib/providers/Travis.js
@@ -14,13 +14,11 @@ class Travis {
 
   parseLog (log) {
     // sp00ky RegExp to start the extraction
-    const reg = /(\[0K\$\s)(?![\s\S]+\1)(.+)\n{2}([\s\S]+)Test failed\./g
+    const reg = /(\[0K\$\s)(?![\s\S]+\1)(.+)\n{2}([\s\S]+)\n.+Test failed\./g
     const result = reg.exec(log)
+
     // const command = result[2]
     let content = result[3]
-
-    // Remove the last line, it's usually extra
-    content = content.substring(0, content.lastIndexOf('\n'))
     return content
   }
 

--- a/lib/template.md
+++ b/lib/template.md
@@ -1,4 +1,8 @@
+### The build is failing
+
 ✨ Good work on this PR so far! ✨ Unfortunately, the [{{ provider }} build]({{ targetUrl }}) is failing. Here's the output:
+
+##### `{{ command }}`
 
 ```
 {{ content }}

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ci-reporter Circle CI creates the correct comment 1`] = `
-"✨ Good work on this PR so far! ✨ Unfortunately, the [Circle CI build](https://circleci.com/gh/JasonEtco/todo/5?utm_campaign&#x3D;vcs-integration-link&amp;utm_medium&#x3D;referral&amp;utm_source&#x3D;github-build-link) is failing. Here's the output:
+"### The build is failing
+
+✨ Good work on this PR so far! ✨ Unfortunately, the [Circle CI build](https://circleci.com/gh/JasonEtco/todo/5?utm_campaign&#x3D;vcs-integration-link&amp;utm_medium&#x3D;referral&amp;utm_source&#x3D;github-build-link) is failing. Here's the output:
+
+##### \`npm test\`
 
 \`\`\`
 &gt; todo@1.0.0 test /home/circleci/repo
@@ -87,7 +91,11 @@ I'm sure you can fix it! If you need help, don't hesitate to ask a maintainer of
 `;
 
 exports[`ci-reporter Travis CI creates the correct comment 1`] = `
-"✨ Good work on this PR so far! ✨ Unfortunately, the [Travis CI build](https://travis-ci.org/JasonEtco/public-test/builds/123?utm_source&#x3D;github_status&amp;utm_medium&#x3D;notification) is failing. Here's the output:
+"### The build is failing
+
+✨ Good work on this PR so far! ✨ Unfortunately, the [Travis CI build](https://travis-ci.org/JasonEtco/public-test/builds/123?utm_source&#x3D;github_status&amp;utm_medium&#x3D;notification) is failing. Here's the output:
+
+##### \`npm test\`
 
 \`\`\`
 &gt; public-test@1.0.0 test /home/travis/build/JasonEtco/public-test

--- a/tests/fixtures/circle/build.json
+++ b/tests/fixtures/circle/build.json
@@ -28,7 +28,7 @@
       "output_url" : "https://circleci.com/fake-output-url",
       "start_time" : "2017-12-25T16:09:56.282Z",
       "background" : false,
-      "exit_code" : 0,
+      "exit_code" : 1,
       "insignificant" : false,
       "canceled" : null,
       "step" : 105,

--- a/tests/fixtures/circle/commit.json
+++ b/tests/fixtures/circle/commit.json
@@ -28,7 +28,7 @@
       "output_url" : "https://circleci.com/fake-output-url",
       "start_time" : "2017-12-25T16:09:56.282Z",
       "background" : false,
-      "exit_code" : 0,
+      "exit_code" : 1,
       "insignificant" : false,
       "canceled" : null,
       "step" : 105,

--- a/tests/providers/__snapshots__/Travis.test.js.snap
+++ b/tests/providers/__snapshots__/Travis.test.js.snap
@@ -1,10 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Travis parseLog returns the correct string 1`] = `
-"> public-test@1.0.0 test /home/travis/build/JasonEtco/public-test
+Object {
+  "command": "npm test",
+  "content": "> public-test@1.0.0 test /home/travis/build/JasonEtco/public-test
 > echo \\"Error: no test specified\\" && exit 1
 
-Error: no test specified"
+Error: no test specified",
+}
 `;
 
 exports[`Travis serialize returns the correct body string 1`] = `


### PR DESCRIPTION
Rather than always looking for `npm test`, instead find the last failing command and consider that the reason for failure. This allows for variable commands, and eventually language-agnostic support! I've also updated the comment template to reflect the failing command.