### PR TITLE
Don't throw errors if there is no Travis match

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://avatars2.githubusercontent.com/in/8035?s=128&v=4" width="64">
   <h3 align="center">ci-reporter</h3>
   <p align="center">A GitHub App built with <a href="https://github.com/probot/probot">Probot</a> that pastes the error output of a failing commit into the relevant PR<p>
-  <p align="center"><a href="https://travis-ci.org/JasonEtco/ci-reporter"><img src="https://img.shields.io/travis/JasonEtco/ci-reporter/master.svg" alt="Build Status"></a> <a href="https://codecov.io/gh/JasonEtco/ci-reporter/"><img src="https://img.shields.io/codecov/c/github/JasonEtco/ci-reporter.svg" alt="Codecov"></a><a href="https://greenkeeper.io"><img src="https://badges.greenkeeper.io/JasonEtco/ci-reporter.svg" alt="Greenkeeper enabled"></a></p>
+  <p align="center"><a href="https://travis-ci.org/JasonEtco/ci-reporter"><img src="https://img.shields.io/travis/JasonEtco/ci-reporter/master.svg" alt="Build Status"></a> <a href="https://codecov.io/gh/JasonEtco/ci-reporter/"><img src="https://img.shields.io/codecov/c/github/JasonEtco/ci-reporter.svg" alt="Codecov"></a> <a href="https://greenkeeper.io"><img src="https://badges.greenkeeper.io/JasonEtco/ci-reporter.svg" alt="Greenkeeper enabled"></a></p>
 </p>
 
 ## Usage

--- a/src/providers/Travis.js
+++ b/src/providers/Travis.js
@@ -18,6 +18,10 @@ class Travis {
     const reg = /(\[0K\$\s)(?![\s\S]+\1)(.+)(?:\r\n|\n)*([\s\S]+)[\r\n]+.*Test failed\./g
     const result = reg.exec(log)
 
+    if (!result) {
+      return false
+    }
+
     const command = result[2]
     let content = result[3].trim()
     return { command, content }
@@ -42,15 +46,18 @@ class Travis {
       headers
     })
 
-    const { command, content } = this.parseLog(res.content)
+    const result = this.parseLog(res.content)
 
-    return {
-      number: buildJson.pull_request_number,
-      data: {
-        provider: 'Travis CI',
-        content: stripAnsi(content),
-        targetUrl,
-        command
+    if (result) {
+      const { content, command } = result
+      return {
+        number: buildJson.pull_request_number,
+        data: {
+          provider: 'Travis CI',
+          content: stripAnsi(content),
+          targetUrl,
+          command
+        }
       }
     }
   }

--- a/tests/providers/Travis.test.js
+++ b/tests/providers/Travis.test.js
@@ -68,11 +68,11 @@ describe('Travis', () => {
 
     it('returns false if there is no match in the log', async () => {
       nock('https://api.travis-ci.org')
-      .get('/build/123').reply(200, {
-        pull_request_number: 1,
-        jobs: [{ id: 1234, number: 1, state: 'failed' }]
-      })
-      .get('/job/1234/log').reply(200, { content: 'Hello!' })
+        .get('/build/123').reply(200, {
+          pull_request_number: 1,
+          jobs: [{ id: 1234, number: 1, state: 'failed' }]
+        })
+        .get('/job/1234/log').reply(200, { content: 'Hello!' })
       const res = await travis.serialize()
       expect(res).toBeFalsy()
     })

--- a/tests/providers/Travis.test.js
+++ b/tests/providers/Travis.test.js
@@ -36,18 +36,16 @@ describe('Travis', () => {
     it('returns the correct string', () => {
       expect(travis.parseLog(log)).toMatchSnapshot()
     })
+
+    it('returns false if there are no matches', () => {
+      expect(travis.parseLog('Hello!')).toBe(false)
+    })
   })
 
   describe('serialize', () => {
     let travis
 
     beforeEach(() => {
-      nock('https://api.travis-ci.org')
-        .get('/build/123').reply(200, {
-          pull_request_number: 1,
-          jobs: [{ id: 1234, number: 1, state: 'failed' }]
-        })
-        .get('/job/1234/log').reply(200, { content: log })
       travis = new Travis({
         payload: {
           target_url: 'https://travis-ci.org/JasonEtco/public-test/builds/123?utm_source=github_status&utm_medium=notification'
@@ -56,9 +54,27 @@ describe('Travis', () => {
     })
 
     it('returns the correct body string', async () => {
+      nock('https://api.travis-ci.org')
+        .get('/build/123').reply(200, {
+          pull_request_number: 1,
+          jobs: [{ id: 1234, number: 1, state: 'failed' }]
+        })
+        .get('/job/1234/log').reply(200, { content: log })
+
       const res = await travis.serialize()
       expect(res.number).toBe(1)
       expect(res.data.content).toMatchSnapshot()
+    })
+
+    it('returns false if there is no match in the log', async () => {
+      nock('https://api.travis-ci.org')
+      .get('/build/123').reply(200, {
+        pull_request_number: 1,
+        jobs: [{ id: 1234, number: 1, state: 'failed' }]
+      })
+      .get('/job/1234/log').reply(200, { content: 'Hello!' })
+      const res = await travis.serialize()
+      expect(res).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
Sometimes, TravisCI will show errors that ci-reporter can't pick up on due to limitations in the Travis API. This PR adds some checks to make sure that ci-reporter has been able to find a matching error log, before crashing the app.