### PR TITLE
Retry if parser fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "probot-ts": "^4.0.1-typescript",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
-    "strip-ansi": "^4.0.0"
+    "strip-ansi": "^4.0.0",
+    "webpack-cli": "^2.0.12"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@google-cloud/logging-bunyan": "^0.7.0",
+    "delay": "^2.0.0",
     "probot": "^5.0.0",
     "probot-ts": "^4.0.1-typescript",
     "request": "^2.83.0",

--- a/src/providers/Travis.js
+++ b/src/providers/Travis.js
@@ -18,16 +18,16 @@ class Travis {
 
   parseLog (log) {
     // sp00ky RegExp to start the extraction
-    const reg = /(\[0K\$\s)(?![\s\S]+\1)(.+)(?:\r\n|\n)*([\s\S]+)[\r\n]+.*Test failed\./g
+    const reg = /\[0K\$\snpm\stest(?:\r\n|\n)*([\s\S]+)[\r\n]+.*Test failed\./g
+
     const result = reg.exec(log)
 
     if (!result) {
       return false
     }
 
-    const command = result[2]
-    let content = result[3].trim()
-    return { command, content }
+    let content = result[1].trim()
+    return { content, command: 'npm test' }
   }
 
   async getLog (job) {

--- a/src/providers/Travis.js
+++ b/src/providers/Travis.js
@@ -1,6 +1,6 @@
 const request = require('request-promise-native')
 const stripAnsi = require('strip-ansi')
-const wait = ms => new Promise((resolve, reject) => setTimeout(resolve, ms))
+const delay = require('delay')
 
 class Travis {
   constructor (context) {
@@ -38,11 +38,13 @@ class Travis {
 
     const result = this.parseLog(res)
 
+    // Travis sometimes sends back incomplete logs
+    // if the request is made too quickly.
     if (!result && this.retries <= 3) {
       this.context.log('Log incomplete; Retrying...')
       this.retries = this.retries + 1
 
-      await wait(500)
+      await delay(500)
       return this.getLog(job)
     }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -37,7 +37,7 @@ describe('ci-reporter', () => {
           pull_request_number: 1,
           jobs: [{ id: 1234, number: 1, state: 'failed' }]
         })
-        .get('/job/1234/log').reply(200, { content: log })
+        .get('/job/1234/log.txt').reply(200, log)
 
       const event = {
         event: 'status',

--- a/tests/providers/Travis.test.js
+++ b/tests/providers/Travis.test.js
@@ -22,7 +22,7 @@ describe('Travis', () => {
   describe('logUri', () => {
     it('creates the correct URI', () => {
       const travis = new Travis()
-      expect(travis.logUri(123)).toBe('https://api.travis-ci.org/job/123/log')
+      expect(travis.logUri(123)).toBe('https://api.travis-ci.org/job/123/log.txt')
     })
   })
 
@@ -49,7 +49,8 @@ describe('Travis', () => {
       travis = new Travis({
         payload: {
           target_url: 'https://travis-ci.org/JasonEtco/public-test/builds/123?utm_source=github_status&utm_medium=notification'
-        }
+        },
+        log: jest.fn()
       })
     })
 
@@ -59,7 +60,7 @@ describe('Travis', () => {
           pull_request_number: 1,
           jobs: [{ id: 1234, number: 1, state: 'failed' }]
         })
-        .get('/job/1234/log').reply(200, { content: log })
+        .get('/job/1234/log.txt').reply(200, log)
 
       const res = await travis.serialize()
       expect(res.number).toBe(1)
@@ -67,12 +68,12 @@ describe('Travis', () => {
     })
 
     it('returns false if there is no match in the log', async () => {
-      nock('https://api.travis-ci.org')
+      nock('https://api.travis-ci.org').persist()
         .get('/build/123').reply(200, {
           pull_request_number: 1,
           jobs: [{ id: 1234, number: 1, state: 'failed' }]
         })
-        .get('/job/1234/log').reply(200, { content: 'Hello!' })
+        .get('/job/1234/log.txt').reply(200, 'Hello!')
       const res = await travis.serialize()
       expect(res).toBeFalsy()
     })


### PR DESCRIPTION
I've noticed (from some [bug reports](https://github.com/JasonEtco/ci-reporter/issues/27)) that Travis builds are sometimes not triggering responses from **ci-reporter**. After some digging, it turns out that the Travis API can send incomplete logs if the request for those logs is made too quickly. The response that Travis returns does not have any mention of the logs being incomplete; they just are 😭 

So, I've implemented some wait-then-retry logic just for the Travis provider class. I've tested this out and it usually fixes itself on the second or third retry.

Closes #27 